### PR TITLE
AXI SRAM support

### DIFF
--- a/src/migen_axi/interconnect/sram.py
+++ b/src/migen_axi/interconnect/sram.py
@@ -1,0 +1,170 @@
+from operator import attrgetter
+from migen import *  # noqa
+from . import axi
+
+__all__ = ["SRAM"]
+
+
+class SRAM(Module):
+    def __init__(self, mem_or_size, read_only=False, init=None, bus=None):
+
+        # SRAM initialisation
+
+        if bus is None:
+            bus = axi.Interface()
+        self.bus = bus
+        bus_data_width = len(self.bus.r.data)
+        if isinstance(mem_or_size, Memory):
+            assert(mem_or_size.width <= bus_data_width)
+            self.mem = mem_or_size
+        else:
+            self.mem = Memory(bus_data_width,
+                              mem_or_size // (bus_data_width // 8),
+                              init=init
+                              )
+
+        # memory
+        port = self.mem.get_port(write_capable=not read_only, we_granularity=8)
+        self.port = port
+        self.specials += self.mem, port
+
+        # # #
+
+        ar, aw, w, r, b = attrgetter("ar", "aw", "w", "r", "b")(bus)
+
+        id_ = Signal(len(ar.id), reset_less=True)
+
+        writing = Signal()
+
+        dout_index = Signal.like(ar.len)
+
+        # todo: add support for bursts
+        # self.r_addr_incr = axi.Incr(ar)
+        # self.w_addr_incr = axi.Incr(aw)
+
+        # # # Read
+
+        self.comb += [
+            r.data.eq(port.dat_r),
+            r.id.eq(id_),
+            r.resp.eq(axi.Response.okay),
+        ]
+
+        # read control
+        self.submodules.read_fsm = read_fsm = FSM(reset_state="IDLE")
+        read_fsm.act(
+            "IDLE",
+            r.valid.eq(0),
+            If(
+                ar.valid & ~writing,
+                NextValue(port.adr, ar.addr[2:]),
+                NextValue(dout_index, 0),
+                NextValue(ar.ready, 1),
+                NextValue(id_, ar.id),
+                NextState("READ_WAIT"),
+            )
+        )
+
+        read_fsm.act(
+            "READ_WAIT",  # need this state to wait one cycle for data
+            NextValue(ar.ready, 0),
+            NextState("READ")
+        )
+
+        read_fsm.act(
+            "READ",
+            r.valid.eq(1),
+            r.last.eq(r.valid & dout_index == ar.len),
+            If(
+                r.last & r.ready,
+                If(  # ar valid? go straight to the next read
+                    ar.valid & ~writing,
+                    NextValue(port.adr, ar.addr[2:]),
+                    NextValue(dout_index, 0),
+                    NextValue(ar.ready, 1),
+                    NextValue(id_, ar.id),
+                    NextState("READ_WAIT"),
+                ).Else(
+                    NextState("IDLE")
+                )
+            )
+        )
+
+        self.sync += [
+            If(
+                r.ready & r.valid,
+                dout_index.eq(dout_index + 1),
+            )
+        ]
+
+        # # # Write
+
+        if not read_only:
+            self.comb += [
+                port.dat_w.eq(w.data),
+                b.id.eq(id_),
+                b.resp.eq(axi.Response.okay),
+            ]
+
+            self.submodules.write_fsm = write_fsm = FSM(reset_state="IDLE")
+            write_fsm.act(
+                "IDLE",
+                w.ready.eq(0),
+                If(
+                    aw.valid,
+                    NextValue(aw.ready, 1),
+                    NextValue(id_, aw.id),
+                    NextValue(writing, 1),
+                    If(
+                        w.valid,  # skip a state if data is ready already
+                        NextValue(port.adr, aw.addr[2:]),
+                        NextState("WRITE"),
+                    ).Else(
+                        NextState("AW_VALID_WAIT")
+                    )
+                )
+            )
+
+            write_fsm.act(
+                "AW_VALID_WAIT",  # wait for data, if not available yet
+                If(
+                    w.valid,
+                    NextValue(port.adr, aw.addr[2:]),
+                    NextState("WRITE"),
+                )
+            )
+
+            write_fsm.act(
+                "WRITE",
+                NextValue(aw.ready, 0),
+                w.ready.eq(1),
+                port.we.eq(w.strb),
+                If(
+                    w.ready & w.last,
+                    NextValue(writing, 0),
+                    NextState("WRITE_RESP")
+                )
+            )
+
+            write_fsm.act(
+                "WRITE_RESP",
+                b.valid.eq(1),
+                If(
+                    b.ready,
+                    If(  # aw valid? go straight for the next write
+                        aw.valid,
+                        NextValue(aw.ready, 1),
+                        NextValue(id_, aw.id),
+                        NextValue(writing, 1),
+                        If(
+                            w.valid,
+                            NextValue(port.adr, aw.addr[2:]),
+                            NextState("WRITE"),
+                        ).Else(
+                            NextState("AW_VALID_WAIT")
+                        )
+                    ).Else(
+                        NextState("IDLE")
+                    )
+                )
+            )

--- a/tests/test_interconnect.py
+++ b/tests/test_interconnect.py
@@ -6,7 +6,7 @@ from migen.sim import run_simulation
 from misoc.interconnect import csr_bus
 import pytest
 from migen_axi.interconnect import *  # noqa
-from migen_axi.interconnect import dmac_bus, stream2axi
+from migen_axi.interconnect import dmac_bus, stream2axi, sram
 from .common import write_ack, wait_stb, ack, csr_w_mon, file_tmp_folder
 
 
@@ -147,6 +147,83 @@ def test_axi2csr(data_width):
 
     run_simulation(dut, testbench_axi2csr(),
                    vcd_name=file_tmp_folder("test_axi2csr.vcd"))
+
+
+def test_sram():
+    # most of the code was copied from CSR, as it also tests SRAM
+    # just with a different interface
+
+    dut = sram.SRAM(0x100, read_only=False, bus=axi.Interface())
+    write_aw = partial(
+        dut.bus.write_aw,
+        size=burst_size(len(dut.bus.w.data) // 8), len_=0,
+        burst=Burst.fixed)
+    write_w = dut.bus.write_w
+    read_b = dut.bus.read_b
+    write_ar = partial(
+        dut.bus.write_ar,
+        size=burst_size(len(dut.bus.r.data) // 8), len_=0,
+        burst=Burst.fixed)
+    read_r = dut.bus.read_r
+    # it's not csr but interface is identical
+    w_mon = partial(csr_w_mon, dut.port)
+
+    def testbench_sram():
+        i = dut.bus
+
+        def aw_channel():
+            assert (yield i.aw.ready) == 0
+            yield from write_aw(0x01, 0x00)
+            assert (yield i.aw.ready) == 1
+            yield from write_aw(0x02, 0x04)
+            yield from write_aw(0x03, 0x08)
+            yield from write_aw(0x04, 0x0c)
+            yield from write_aw(0x05, 0x40)
+
+        def w_channel():
+            yield from write_w(0, 0x11, strb=1)
+            yield from write_w(0, 0x22, strb=1)
+            yield from write_w(0, 0x33, strb=1)
+            yield from write_w(0, 0x44, strb=1)
+            yield from write_w(0, 0x11223344)
+
+        def b_channel():
+            assert attrgetter_b((yield from read_b())) == (0x01, okay)
+            assert attrgetter_b((yield from read_b())) == (0x02, okay)
+            assert attrgetter_b((yield from read_b())) == (0x03, okay)
+            assert attrgetter_b((yield from read_b())) == (0x04, okay)
+            assert attrgetter_b((yield from read_b())) == (0x05, okay)
+
+        def ar_channel():
+            # ensure data was actually written
+            assert attrgetter_csr_w_mon((yield from w_mon())) == (0x00, 0x11)
+            assert attrgetter_csr_w_mon((yield from w_mon())) == (0x01, 0x22)
+            assert attrgetter_csr_w_mon((yield from w_mon())) == (0x02, 0x33)
+            assert attrgetter_csr_w_mon((yield from w_mon())) == (0x03, 0x44)
+            # unlike csr, data width here can be only 32 bits, not 8/16
+            assert attrgetter_csr_w_mon(
+                (yield from w_mon())) == (0x10, 0x11223344)
+            # ok, read it now
+            yield from write_ar(0x11, 0x00)
+            yield from write_ar(0x22, 0x04)
+            yield from write_ar(0x33, 0x08)
+            yield from write_ar(0x44, 0x0c)
+            yield from write_ar(0x55, 0x40)
+
+        def r_channel():
+            assert attrgetter_r((yield from read_r())) == (0x11, 0x11, okay, 1)
+            assert attrgetter_r((yield from read_r())) == (0x22, 0x22, okay, 1)
+            assert attrgetter_r((yield from read_r())) == (0x33, 0x33, okay, 1)
+            assert attrgetter_r((yield from read_r())) == (0x44, 0x44, okay, 1)
+            assert attrgetter_r(
+                (yield from read_r())) == (0x55, 0x11223344, okay, 1)
+
+        return [
+            aw_channel(), w_channel(), b_channel(), r_channel(), ar_channel(),
+        ]
+
+    run_simulation(dut, testbench_sram(),
+                   vcd_name=file_tmp_folder("test_sram.vcd"))
 
 
 def test_read_requester():


### PR DESCRIPTION
This PR aims to add support for SRAM connected directly to AXI bus, rather than CSR (through axi2csr) or Wishbone.

The tests for the code were modified from AXI2CSR tests, and they seem to work very well for this purpose. 