### PR TITLE
allow user-defined system clock

### DIFF
--- a/src/migen_axi/cores/ps7.py
+++ b/src/migen_axi/cores/ps7.py
@@ -351,7 +351,7 @@ class ENET(Module):
 
 class PS7(Module):
     def __init__(self, pads=SimpleNamespace(
-            ps=None, ddr=None, enet0=None, enet1=None), **kwargs):
+            ps=None, ddr=None, enet0=None, enet1=None), ps_cd_sys=True, **kwargs):
         pads.ps = pads.ps or ps_rec()
         pads.ddr = pads.ddr or ddr_rec()
 
@@ -396,7 +396,8 @@ class PS7(Module):
         self.ddr_arb = Signal(4)
         self.mio = Signal(54)
 
-        self.clock_domains.cd_sys = ClockDomain()
+        if ps_cd_sys:
+            self.clock_domains.cd_sys = ClockDomain()
 
         self.dma0 = dmac_bus.Interface(name="dma0")
         self.dma1 = dmac_bus.Interface(name="dma1")
@@ -490,11 +491,12 @@ class PS7(Module):
         ]
 
         self.fclk = fclk_rec()
-        # fclk.reset_n considered async
-        self.specials += [
-            AsyncResetSynchronizer(self.cd_sys, ~self.fclk.reset_n[0]),
-            bufg([self.fclk.clk[0], ClockSignal()]),
-        ]
+        if ps_cd_sys:
+            # fclk.reset_n considered async
+            self.specials += [
+                AsyncResetSynchronizer(self.cd_sys, ~self.fclk.reset_n[0]),
+                bufg([self.fclk.clk[0], ClockSignal()]),
+            ]
 
         self.comb += self.fclk.clktrig_n.eq(0)
         ftmd = ftmd_rec()

--- a/src/migen_axi/integration/soc_core.py
+++ b/src/migen_axi/integration/soc_core.py
@@ -26,7 +26,8 @@ class SoCCore(Module):
                  csr_data_width=8,
                  csr_address_width=14,
                  max_addr=0xc0000000,
-                 ident="SoCCore"):
+                 ident="SoCCore",
+                 ps_cd_sys=True):
         self.platform = platform
         self.integrated_rom_size = 0
         self.cpu_type = "zynq7000"
@@ -52,7 +53,7 @@ class SoCCore(Module):
         self.submodules.ps7 = ps7.PS7(SimpleNamespace(
             ps=platform.request("ps"),
             ddr=platform.request("ddr"),
-        ))
+        ), ps_cd_sys=ps_cd_sys)
 
         self.submodules.axi2csr = axi2csr.AXI2CSR(
             bus_csr=csr_bus.Interface(csr_data_width, csr_address_width),


### PR DESCRIPTION
Defining and driving the system clock domain from the PS can now be optionally disabled.

This allows the user to use their own system clock domain, which can help reduce the number of different clock domains in some applications, allowing reductions in latency, complexity and resource usage.

By default the system clock domain remains driven from the PS, to keep backward compatibility.