### PR TITLE
axi2csr: fix decoder to work with diff mem size

### DIFF
--- a/src/migen_axi/interconnect/axi2csr.py
+++ b/src/migen_axi/interconnect/axi2csr.py
@@ -40,6 +40,11 @@ class AXI2CSR(Module):
 
         self.specials += port
 
+        # to assign a unique address decoding expression for memories with different size
+        # starting address must be aligned to the size of the memory
+        padding = (size - (self._relative_addr % size)) % size
+        self._relative_addr += padding
+
         # check if the remaining part of the address bus
         # corresponds to the possible address
         cut_addr = self._relative_addr >> 2


### PR DESCRIPTION
## Summary
- fix #32 
- Inspired by [zipcpu's "Understanding AutoFPGA's address assignment algorithm"](https://zipcpu.com/zipcpu/2019/09/03/address-assignment.html#tightly-packing-addresses), unused address space is added between small and large memory size to ensure they have a unique decoding expression which is similar to Spaqin's "oversizing the memory to work around this issue" idea. 

@Spaqin 